### PR TITLE
1.6.8 beta

### DIFF
--- a/toolbox/menu.py
+++ b/toolbox/menu.py
@@ -6,7 +6,6 @@ from utils.toolbox import runRegularNode, runFullNode, refreshStats
 
 if __name__ == "__main__":
     # clear screen, show logo
-    os.system("clear")
     loaderIntro()
     # check for .env file, if none we have a first timer.
     if os.path.exists(validatorToolbox.dotenv_file) is None:

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -62,12 +62,14 @@ def statsOutputRegular() -> None:
     printStars()
     while count < 4:
         try:
+            count += count
             remote_data, local_data = multiValidatorStats(count)
             print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
             print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {getDBSize(environ.get('SHARD'))}")
             printStars()
         except (ValueError, KeyError, TypeError):
-            return
+            print(f'Shard {count} not found.')
+        
 
 def multiValidatorStats(shard):
     loadVarFile()

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -105,7 +105,7 @@ def statsOutputRegular(folders) -> None:
     print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}\n* Current disk space free: {Fore.CYAN}{freeSpaceCheck(): >6}{Style.RESET_ALL}\n* Current harmony version: {Fore.YELLOW}{environ.get("HARMONY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HARMONY_UPGRADE_AVAILABLE")}\n* Current hmy version: {Fore.YELLOW}{environ.get("HMY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HMY_UPGRADE_AVAILABLE")}')
     print(f"* CPU Load Averages: {round(Load1, 2)} over 1 min, {round(Load5, 2)} over 5 min, {round(Load15, 2)} over 15 min")
     printStars()
-    remote_shard_0 = [f"{user_home}/{folders[0][0]}/hmy", "utility", "metadata", f"--node=https://api.s0.t.hmny.io"]
+    remote_shard_0 = [f"{user_home}/{list(folders.items())[0][0]}/hmy", "utility", "metadata", f"--node=https://api.s0.t.hmny.io"]
     result_shard_0 = run(remote_shard_0, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     remote_0_data = json.loads(result_shard_0.stdout)
     print(f"* Remote Shard 0 Epoch: {remote_0_data['result']['current-epoch']}, Current Block: {remote_0_data['result']['current-block-number']}")

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -62,18 +62,23 @@ if not os.path.exists(f"{validatorToolbox.harmonyDirPath}"):
     if os.path.exists(f"{validatorToolbox.harmonyDirPath}"):
         port = findPort(f'harmony')
         folders['harmony'] = port
+        print(f'Found ~/harmony folder, on port {port}')
     if os.path.exists(f"{validatorToolbox.harmonyDirPath}0"):
         port = findPort(f'harmony0')
         folders['harmony1'] = port
+        print(f'Found ~/harmony1 folder, on port {port}')
     if os.path.exists(f"{validatorToolbox.harmonyDirPath}1"):
         port = findPort(f'harmony1')
         folders['harmony2'] = port
+        print(f'Found ~/harmony1 folder, on port {port}')
     if os.path.exists(f"{validatorToolbox.harmonyDirPath}2"):
         port = findPort(f'harmony2')
         folders['harmony3'] = port
+        print(f'Found ~/harmony2 folder, on port {port}')
     if os.path.exists(f"{validatorToolbox.harmonyDirPath}3"):
         port = findPort(f'harmony3')
         folders['harmony4'] = port
+        print(f'Found ~/harmony3 folder, on port {port}')
     for folder in folders:
         #let's figure out what shards here.
         local_server = [f"{validatorToolbox.userHomeDir}/{folder}/hmy blockchain latest-headers --node='https://localhost:{folders[folder]}'"]

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -74,12 +74,11 @@ if not os.path.exists(f"{validatorToolbox.harmonyDirPath}"):
     if os.path.exists(f"{validatorToolbox.harmonyDirPath}3"):
         port = findPort(f'harmony3')
         folders['harmony4'] = port
-
-for folder in folders:
-    #let's figure out what shards here.
-    local_server = [f"{validatorToolbox.userHomeDir}/{folder}/hmy blockchain latest-headers --node='https://localhost:{folders[folder]}'"]
-    result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    print(result_local_server)
+    for folder in folders:
+        #let's figure out what shards here.
+        local_server = [f"{validatorToolbox.userHomeDir}/{folder}/hmy blockchain latest-headers --node='https://localhost:{folders[folder]}'"]
+        result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        print(result_local_server)
 
 def statsOutputRegular() -> None:
     # Get server stats & wallet balances

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -109,7 +109,7 @@ def statsOutputRegular(folders) -> None:
     result_shard_0 = run(remote_shard_0, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     remote_0_data = json.loads(result_shard_0.stdout)
     print(f"* Remote Shard 0 Epoch: {remote_0_data['result']['current-epoch']}, Current Block: {remote_0_data['result']['current-block-number']}")
-    print(f"* Local Shard 0 Storage: {getDBSize("0")}")
+    print(f"* Local Shard 0 Storage: {getDBSize('0')}")
     for folder in folders:
         local_server = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=http://localhost:{folders[folder]}"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -82,7 +82,7 @@ def getFolders():
         print(f'Found ~/harmony3 folder, on port {port}')
     for folder in folders:
         #let's figure out what shards here.
-        local_server = f"{user_home}/{folder}/hmy blockchain latest-headers --node='https://localhost:{folders[folder]}'"
+        local_server = [f"{user_home}/{folder}/hmy blockchain latest-headers --node='http://localhost:{folders[folder]}'"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         print(result_local_server)
     return folders

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -7,6 +7,7 @@ from utils.library import loadVarFile, getSignPercent, getWalletBalance, printSt
 from utils.toolbox import freeSpaceCheck, harmonyServiceStatus, getRewardsBalance, getDBSize, refreshStats
 from subprocess import PIPE, run
 from colorama import Fore, Back, Style
+from simple_term_menu import TerminalMenu
 
 loadVarFile()
 
@@ -17,12 +18,39 @@ if not environ.get("VALIDATOR_WALLET"):
     if address == address2:
         setVar(validatorToolbox.dot_env, "VALIDATOR_WALLET", address2)
 
+if not environ.get("NETWORK_SWITCH"):
+    # ask for mainnet or testnet
+    os.system("clear")
+    printStars()
+    print("* Setup config not found, which blockchain does this node run on?                           *")
+    printStars()
+    print("* [0] - Mainnet                                                                             *")
+    print("* [1] - Testnet                                                                             *")
+    printStars()
+    menuOptions = [
+        "[0] Mainnet",
+        "[1] Testnet",
+    ]
+    terminal_menu = TerminalMenu(menuOptions, title="Mainnet or Testnet")
+    results = terminal_menu.show()
+    if results == 0:
+        setVar(validatorToolbox.dotenv_file, "NETWORK", "mainnet")
+        setVar(validatorToolbox.dotenv_file, "NETWORK_SWITCH", "t")
+        setVar(validatorToolbox.dotenv_file, "RPC_NET", "https://rpc.s0.t.hmny.io")
+    if results == 1:
+        setVar(validatorToolbox.dotenv_file, "NETWORK", "testnet")
+        setVar(validatorToolbox.dotenv_file, "NETWORK_SWITCH", "b")
+        setVar(validatorToolbox.dotenv_file, "RPC_NET", "https://rpc.s0.b.hmny.io")
+    os.system("clear")
+    return
+
 def statsOutputRegular() -> None:
-    # Get stats & balances
+    # Get server stats & wallet balances
     Load1, Load5, Load15 = os.getloadavg()
     sign_percentage = getSignPercent()
     total_balance, total_balance_test = getWalletBalance(environ.get("VALIDATOR_WALLET"))
-    remote_data_shard_0, local_data_shard, remote_data_shard = menuValidatorStats()
+    # Get shard stats here
+    count = 0
     os.system("clear")
     # Print Menu
     printStars()
@@ -31,46 +59,34 @@ def statsOutputRegular() -> None:
     print(f'* Your validator wallet address is: {Fore.RED}{str(environ.get("VALIDATOR_WALLET"))}{Style.RESET_ALL}\n* Your $ONE balance is:             {Fore.GREEN}{str(total_balance)}{Style.RESET_ALL}\n* Your pending $ONE rewards are:    {Fore.GREEN}{str(getRewardsBalance(validatorToolbox.rpc_endpoints, environ.get("VALIDATOR_WALLET")))}{Style.RESET_ALL}\n* Server Hostname & IP:             {validatorToolbox.serverHostName}{Style.RESET_ALL} - {Fore.YELLOW}{validatorToolbox.ourExternalIPAddress}{Style.RESET_ALL}')
     harmonyServiceStatus()
     print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}\n* Current disk space free: {Fore.CYAN}{freeSpaceCheck(): >6}{Style.RESET_ALL}\n* Current harmony version: {Fore.YELLOW}{environ.get("HARMONY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HARMONY_UPGRADE_AVAILABLE")}\n* Current hmy version: {Fore.YELLOW}{environ.get("HMY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HMY_UPGRADE_AVAILABLE")}')
-    printStars()
-    if environ.get("SHARD") != "0":
-        print(f"\n* Note: Running on shard {environ.get('SHARD')}, Shard 0 is no longer needed locally and should be under 200MB\n* Remote Shard 0 Epoch: {remote_data_shard_0['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard_0['result']['shard-chain-header']['number'])}, Local Shard 0 Size: {getDBSize('0')}")
-        print(f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard['result']['shard-chain-header']['number'])}")
-        print(f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data_shard['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {getDBSize(environ.get('SHARD'))}")
-    if environ.get("SHARD") == "0":
-        print(f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data_shard_0['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard_0['result']['shard-chain-header']['number'])}")
-        print(f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data_shard['result']['shard-chain-header']['number'])}")
     print(f"* CPU Load Averages: {round(Load1, 2)} over 1 min, {round(Load5, 2)} over 5 min, {round(Load15, 2)} over 15 min")
     printStars()
+    while count < 4:
+        try:
+            remote_data, local_data = multiValidatorStats()
+            print(f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
+            print(f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {getDBSize(environ.get('SHARD'))}")
+            printStars()
+        except (ValueError, KeyError, TypeError):
+            return
 
-def menuValidatorStats():
+def multiValidatorStats(shard):
     loadVarFile()
-    remote_shard_0 = [
+    remote_shard = [
         f"{validatorToolbox.hmyAppPath}",
         "blockchain",
         "latest-headers",
-        f'--node=https://api.s0.{environ.get("NETWORK_SWITCH")}.hmny.io',
+        f'--node=https://api.s{shard}.{environ.get("NETWORK_SWITCH")}.hmny.io',
     ]
-    result_remote_shard_0 = run(remote_shard_0, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    remote_data_shard_0 = json.loads(result_remote_shard_0.stdout)
-    local_shard = [f"{validatorToolbox.hmyAppPath}", "blockchain", "latest-headers"]
+    result_remote_shard = run(remote_shard, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    remote_data = json.loads(result_remote_shard.stdout)
+
+    # local stuff
+    local_shard = [f"{validatorToolbox.hmyAppPath}", "blockchain", "latest-headers", f'--node=https://localhost:950{shard}']
     result_local_shard = run(local_shard, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    local_data_shard = json.loads(result_local_shard.stdout)
-            
-    if environ.get("SHARD") != "0":
-        remote_shard = [
-            f"{validatorToolbox.hmyAppPath}",
-            "blockchain",
-            "latest-headers",
-            f'--node=https://api.s{environ.get("SHARD")}.{environ.get("NETWORK_SWITCH")}.hmny.io',
-        ]
-        try:
-            result_remote_shard = run(remote_shard, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-            remote_data_shard = json.loads(result_remote_shard.stdout)
-            return remote_data_shard_0, local_data_shard, remote_data_shard
-        except (ValueError, KeyError, TypeError):
-            return
+    local_data = json.loads(result_local_shard.stdout)
         
-    return remote_data_shard_0, local_data_shard, None
+    return remote_data, local_data
 
 if __name__ == "__main__":
     loaderIntro()

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -119,8 +119,8 @@ def statsOutputRegular(folders) -> None:
         result_remote_server = run(remote_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         remote_data = json.loads(result_remote_server.stdout)
 
-        print(f"* Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
-        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}\n* Local Shard {local_data['result']['shard-id']} Size: {getDBSize(local_data['result']['shard-id'])}")
+        print(f"*  Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
+        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}\n*  Local Shard {local_data['result']['shard-id']} Size: {getDBSize(local_data['result']['shard-id'])}")
         printStars()
 
 if __name__ == "__main__":

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -82,7 +82,7 @@ def getFolders():
         print(f'Found ~/harmony3 folder, on port {port}')
     for folder in folders:
         #let's figure out what shards here.
-        local_server = [f"{user_home}/{folder}/hmy blockchain latest-headers --node=http://localhost:{folders[folder]}"]
+        local_server = [f"{user_home}/{folder}/hmy", "blockchain", "latest-headers", f"--node=http://localhost:{folders[folder]}"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         local_data = json.loads(result_local_server.stdout)
         print(result_local_server)

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -103,12 +103,15 @@ def statsOutputRegular(folders) -> None:
 
     for folder in folders:
         #let's figure out what shards here.
-        local_server = [f"{user_home}/{folder}/hmy", "blockchain", "latest-headers", f"--node=http://localhost:{folders[folder]}"]
-        remote_server = [f"{user_home}/{folder}/hmy", "blockchain", "latest-headers", f"--node=http://rpc.s0.t.hmny"]
+        local_server = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=http://localhost:{folders[folder]}"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         local_data = json.loads(result_local_server.stdout)
-        print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
-        print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {count} Size: {getDBSize(str(count))}")
+        remote_server = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=https://api.s{local_data['result']['shard-id']}.t.hmny.io"]
+        result_remote_server = run(remote_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        remote_data = json.loads(result_remote_server.stdout)
+
+        print(f"* Remote Shard {count} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
+        print(f"*  Local Shard {count} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}, Local Shard {local_data['result']['shard-id']} Size: {getDBSize(str(count))}")
         printStars()
         
 

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -83,7 +83,7 @@ def getFolders():
     return folders
 
 
-def statsOutputRegular() -> None:
+def statsOutputRegular(folders) -> None:
     # Get server stats & wallet balances
     Load1, Load5, Load15 = os.getloadavg()
     sign_percentage = getSignPercent()
@@ -104,6 +104,7 @@ def statsOutputRegular() -> None:
     for folder in folders:
         #let's figure out what shards here.
         local_server = [f"{user_home}/{folder}/hmy", "blockchain", "latest-headers", f"--node=http://localhost:{folders[folder]}"]
+        remote_server = [f"{user_home}/{folder}/hmy", "blockchain", "latest-headers", f"--node=http://rpc.s0.t.hmny"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         local_data = json.loads(result_local_server.stdout)
         print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -64,7 +64,7 @@ def statsOutputRegular() -> None:
         try:
             remote_data, local_data = multiValidatorStats(count)
             print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
-            print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {getDBSize(environ.get('SHARD'))}")
+            print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {count} Size: {getDBSize(count)}")
             printStars()
             count += 1
         except (ValueError, KeyError, TypeError):

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -69,6 +69,7 @@ def statsOutputRegular() -> None:
             count += 1
         except (ValueError, KeyError, TypeError):
             print(f'Shard {count} not found.')
+            count += 1
         
 
 def multiValidatorStats(shard):

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -3,8 +3,8 @@ import json
 from os import environ
 from ast import literal_eval
 from utils.config import validatorToolbox
-from utils.library import loadVarFile, getSignPercent, getWalletBalance, printStars, setVar
-from utils.toolbox import freeSpaceCheck, harmonyServiceStatus, getRewardsBalance
+from utils.library import loadVarFile, getSignPercent, getWalletBalance, printStars, setVar, loaderIntro
+from utils.toolbox import freeSpaceCheck, harmonyServiceStatus, getRewardsBalance, getDBSize, refreshStats
 from subprocess import PIPE, run
 from colorama import Fore, Back, Style
 
@@ -73,5 +73,7 @@ def menuValidatorStats():
     return remote_data_shard_0, local_data_shard, None
 
 if __name__ == "__main__":
+    loaderIntro()
+    refreshStats(1)
     statsOutputRegular()
     

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -120,7 +120,7 @@ def statsOutputRegular(folders) -> None:
         remote_data = json.loads(result_remote_server.stdout)
 
         print(f"* Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
-        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}\nLocal Shard {local_data['result']['shard-id']} Size: {getDBSize(local_data['result']['shard-id'])}")
+        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}\n* Local Shard {local_data['result']['shard-id']} Size: {getDBSize(local_data['result']['shard-id'])}")
         printStars()
 
 if __name__ == "__main__":

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -70,6 +70,5 @@ def menuTopperRegular() -> None:
     return remote_data_shard_0, local_data_shard, None
 
 if __name__ == "__main__":
-    loadVarFile()
     menuValidatorStats()
     

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -105,7 +105,7 @@ def statsOutputRegular(folders) -> None:
     print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}\n* Current disk space free: {Fore.CYAN}{freeSpaceCheck(): >6}{Style.RESET_ALL}\n* Current harmony version: {Fore.YELLOW}{environ.get("HARMONY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HARMONY_UPGRADE_AVAILABLE")}\n* Current hmy version: {Fore.YELLOW}{environ.get("HMY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HMY_UPGRADE_AVAILABLE")}')
     print(f"* CPU Load Averages: {round(Load1, 2)} over 1 min, {round(Load5, 2)} over 5 min, {round(Load15, 2)} over 15 min")
     printStars()
-    remote_shard_0 = [f"{user_home}/{folders[0]}/hmy", "utility", "metadata", f"--node=https://api.s0.t.hmny.io"]
+    remote_shard_0 = [f"{user_home}/{folders[0][0]}/hmy", "utility", "metadata", f"--node=https://api.s0.t.hmny.io"]
     result_shard_0 = run(remote_shard_0, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     remote_0_data = json.loads(result_shard_0.stdout)
     print(f"* Remote Shard 0 Epoch: {remote_0_data['result']['current-epoch']}, Current Block: {remote_0_data['result']['current-block-number']}")

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -64,7 +64,7 @@ def statsOutputRegular() -> None:
         try:
             remote_data, local_data = multiValidatorStats(count)
             print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
-            print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {count} Size: {getDBSize(count)}")
+            print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {count} Size: {getDBSize(str(count))}")
             printStars()
             count += 1
         except (ValueError, KeyError, TypeError):

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -11,6 +11,10 @@ from simple_term_menu import TerminalMenu
 
 loadVarFile()
 
+user_home = f'{os.path.expanduser("~")}'
+
+validatorToolbox.harmonyDirPath
+
 if not environ.get("VALIDATOR_WALLET"):
     # ask for wallet, save to env.
     address = input(f'No Harmony $ONE address found, please input a one1 or 0x address: ')
@@ -56,7 +60,7 @@ def findPort(folder):
             count += 1
 
 # build list of installs
-if not os.path.exists(f"{validatorToolbox.harmonyDirPath}"):
+if not os.path.exists(f"{}"):
     print(f'* Checking for custom folders.')
     folders = {}
     if os.path.exists(f"{validatorToolbox.harmonyDirPath}"):

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -84,6 +84,7 @@ def getFolders():
         #let's figure out what shards here.
         local_server = [f"{user_home}/{folder}/hmy blockchain latest-headers --node=http://localhost:{folders[folder]}"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        local_data = json.loads(result_local_server.stdout)
         print(result_local_server)
     return folders
 

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -1,9 +1,12 @@
 import os
+import json
 from os import environ
+from ast import literal_eval
 from utils.config import validatorToolbox
 from utils.library import loadVarFile, getSignPercent, getWalletBalance, printStars, setVar
-from utils.toolbox import menuTopperRegular, freeSpaceCheck
+from utils.toolbox import menuTopperRegular, freeSpaceCheck, harmonyServiceStatus
 from subprocess import PIPE, run
+from colorama import Fore, Back, Style
 
 loadVarFile()
 
@@ -39,7 +42,7 @@ def menuTopperRegular() -> None:
     print(f"* CPU Load Averages: {round(Load1, 2)} over 1 min, {round(Load5, 2)} over 5 min, {round(Load15, 2)} over 15 min")
     printStars()
 
-    def menuValidatorStats():
+def menuValidatorStats():
     loadVarFile()
     remote_shard_0 = [
         f"{validatorToolbox.hmyAppPath}",

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -105,9 +105,9 @@ def statsOutputRegular() -> None:
     print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}\n* Current disk space free: {Fore.CYAN}{freeSpaceCheck(): >6}{Style.RESET_ALL}\n* Current harmony version: {Fore.YELLOW}{environ.get("HARMONY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HARMONY_UPGRADE_AVAILABLE")}\n* Current hmy version: {Fore.YELLOW}{environ.get("HMY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HMY_UPGRADE_AVAILABLE")}')
     print(f"* CPU Load Averages: {round(Load1, 2)} over 1 min, {round(Load5, 2)} over 5 min, {round(Load15, 2)} over 15 min")
     printStars()
-    for i in folders:
+    for folder in folders:
         try:
-            remote_data, local_data = multiValidatorStats(i)
+            remote_data, local_data = multiValidatorStats(folder)
             print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
             print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {count} Size: {getDBSize(str(count))}")
             printStars()
@@ -118,7 +118,7 @@ def statsOutputRegular() -> None:
 def multiValidatorStats(folder):
     loadVarFile()
     remote_shard = [
-        f"{validatorToolbox.userHomeDir}/{folder[0]}/hmy",
+        f"{validatorToolbox.userHomeDir}/{folders[folder]}/hmy",
         "blockchain",
         "latest-headers",
         f'--node=https://api.s{shard}.{environ.get("NETWORK_SWITCH")}.hmny.io',

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -62,7 +62,7 @@ def statsOutputRegular() -> None:
     printStars()
     while count < 4:
         try:
-            remote_data, local_data = multiValidatorStats()
+            remote_data, local_data = multiValidatorStats(count)
             print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
             print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {getDBSize(environ.get('SHARD'))}")
             printStars()

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -82,7 +82,7 @@ def getFolders():
         print(f'Found ~/harmony3 folder, on port {port}')
     for folder in folders:
         #let's figure out what shards here.
-        local_server = [f"{user_home}/{folder}/hmy blockchain latest-headers --node='https://localhost:{folders[folder]}'"]
+        local_server = f"{user_home}/{folder}/hmy blockchain latest-headers --node='https://localhost:{folders[folder]}'"
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         print(result_local_server)
     return folders

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -105,7 +105,7 @@ def statsOutputRegular(folders) -> None:
     print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}\n* Current disk space free: {Fore.CYAN}{freeSpaceCheck(): >6}{Style.RESET_ALL}\n* Current harmony version: {Fore.YELLOW}{environ.get("HARMONY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HARMONY_UPGRADE_AVAILABLE")}\n* Current hmy version: {Fore.YELLOW}{environ.get("HMY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HMY_UPGRADE_AVAILABLE")}')
     print(f"* CPU Load Averages: {round(Load1, 2)} over 1 min, {round(Load5, 2)} over 5 min, {round(Load15, 2)} over 15 min")
     printStars()
-    remote_shard_0 = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=https://api.s0.t.hmny.io"]
+    remote_shard_0 = [f"{user_home}/{folders[0]}/hmy", "utility", "metadata", f"--node=https://api.s0.t.hmny.io"]
     result_shard_0 = run(remote_shard_0, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     remote_0_data = json.loads(result_shard_0.stdout)
     print(f"* Remote Shard 0 Epoch: {remote_0_data['result']['current-epoch']}, Current Block: {remote_0_data['result']['current-block-number']}")

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -100,9 +100,8 @@ def statsOutputRegular(folders) -> None:
     print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}\n* Current disk space free: {Fore.CYAN}{freeSpaceCheck(): >6}{Style.RESET_ALL}\n* Current harmony version: {Fore.YELLOW}{environ.get("HARMONY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HARMONY_UPGRADE_AVAILABLE")}\n* Current hmy version: {Fore.YELLOW}{environ.get("HMY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HMY_UPGRADE_AVAILABLE")}')
     print(f"* CPU Load Averages: {round(Load1, 2)} over 1 min, {round(Load5, 2)} over 5 min, {round(Load15, 2)} over 15 min")
     printStars()
-
+    count = 0
     for folder in folders:
-        #let's figure out what shards here.
         local_server = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=http://localhost:{folders[folder]}"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         local_data = json.loads(result_local_server.stdout)
@@ -110,8 +109,8 @@ def statsOutputRegular(folders) -> None:
         result_remote_server = run(remote_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         remote_data = json.loads(result_remote_server.stdout)
 
-        print(f"* Remote Shard {count} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
-        print(f"*  Local Shard {count} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}, Local Shard {local_data['result']['shard-id']} Size: {getDBSize(str(count))}")
+        print(f"* Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
+        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}, Local Shard {local_data['result']['shard-id']} Size: {getDBSize(str(count))}")
         printStars()
 
 if __name__ == "__main__":

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -82,7 +82,7 @@ def getFolders():
         print(f'Found ~/harmony3 folder, on port {port}')
     for folder in folders:
         #let's figure out what shards here.
-        local_server = [f"{user_home}/{folder}/hmy blockchain latest-headers --node='http://localhost:{folders[folder]}'"]
+        local_server = [f"{user_home}/{folder}/hmy blockchain latest-headers --node=http://localhost:{folders[folder]}"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         print(result_local_server)
     return folders
@@ -132,7 +132,7 @@ def multiValidatorStats(folder):
         result_local_shard = run(local_shard, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         local_data = json.loads(result_local_shard.stdout)
     else:
-        local_shard = [f"{validatorToolbox.userHomeDir}/{folder}/hmy", "blockchain", "latest-headers", f"--node='http://localhost:{folder[1]}"]
+        local_shard = [f"{validatorToolbox.userHomeDir}/{folder}/hmy", "blockchain", "latest-headers", f"--node=http://localhost:{folder[1]}"]
         
     return remote_data, local_data
 

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -1,0 +1,75 @@
+import os
+from os import environ
+from utils.config import validatorToolbox
+from utils.library import loadVarFile, getSignPercent, getWalletBalance, printStars, setVar
+from utils.toolbox import menuTopperRegular, freeSpaceCheck
+from subprocess import PIPE, run
+
+loadVarFile()
+
+if not environ.get("VALIDATOR_WALLET"):
+    # ask for wallet, save to env.
+    address = input(f'No Harmony $ONE address found, please input a one1 or 0x address: ')
+    address2 = input(f'Please re-enter your address to verify: ')
+    if address == address2:
+        setVar(validatorToolbox.dot_env, "VALIDATOR_WALLET", address2)
+
+def menuTopperRegular() -> None:
+    # Get stats & balances
+    Load1, Load5, Load15 = os.getloadavg()
+    sign_percentage = getSignPercent()
+    total_balance, total_balance_test = getWalletBalance(environ.get("VALIDATOR_WALLET"))
+    remote_data_shard_0, local_data_shard, remote_data_shard = menuValidatorStats()
+    os.system("clear")
+    # Print Menu
+    printStars()
+    print(f'{Style.RESET_ALL}* {Fore.GREEN}validator-toolbox for Harmony ONE Validators by Easy Node   v{validatorToolbox.easyVersion}{Style.RESET_ALL}   https://easynode.one *')
+    printStars()
+    print(f'* Your validator wallet address is: {Fore.RED}{str(environ.get("VALIDATOR_WALLET"))}{Style.RESET_ALL}\n* Your $ONE balance is:             {Fore.GREEN}{str(total_balance)}{Style.RESET_ALL}\n* Your pending $ONE rewards are:    {Fore.GREEN}{str(getRewardsBalance(validatorToolbox.rpc_endpoints, environ.get("VALIDATOR_WALLET")))}{Style.RESET_ALL}\n* Server Hostname & IP:             {validatorToolbox.serverHostName}{Style.RESET_ALL} - {Fore.YELLOW}{validatorToolbox.ourExternalIPAddress}{Style.RESET_ALL}')
+    harmonyServiceStatus()
+    print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}\n* Current disk space free: {Fore.CYAN}{freeSpaceCheck(): >6}{Style.RESET_ALL}\n* Current harmony version: {Fore.YELLOW}{environ.get("HARMONY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HARMONY_UPGRADE_AVAILABLE")}\n* Current hmy version: {Fore.YELLOW}{environ.get("HMY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HMY_UPGRADE_AVAILABLE")}')
+    printStars()
+    if environ.get("SHARD") != "0":
+        print(f"\n* Note: Running on shard {environ.get('SHARD')}, Shard 0 is no longer needed locally and should be under 200MB\n* Remote Shard 0 Epoch: {remote_data_shard_0['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard_0['result']['shard-chain-header']['number'])}, Local Shard 0 Size: {getDBSize('0')}")
+        print(f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard['result']['shard-chain-header']['number'])}")
+        print(f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data_shard['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {getDBSize(environ.get('SHARD'))}")
+    if environ.get("SHARD") == "0":
+        print(f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data_shard_0['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data_shard_0['result']['shard-chain-header']['number'])}")
+        print(f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data_shard['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data_shard['result']['shard-chain-header']['number'])}")
+    print(f"* CPU Load Averages: {round(Load1, 2)} over 1 min, {round(Load5, 2)} over 5 min, {round(Load15, 2)} over 15 min")
+    printStars()
+
+    def menuValidatorStats():
+    loadVarFile()
+    remote_shard_0 = [
+        f"{validatorToolbox.hmyAppPath}",
+        "blockchain",
+        "latest-headers",
+        f'--node=https://api.s0.{environ.get("NETWORK_SWITCH")}.hmny.io',
+    ]
+    result_remote_shard_0 = run(remote_shard_0, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    remote_data_shard_0 = json.loads(result_remote_shard_0.stdout)
+    local_shard = [f"{validatorToolbox.hmyAppPath}", "blockchain", "latest-headers"]
+    result_local_shard = run(local_shard, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    local_data_shard = json.loads(result_local_shard.stdout)
+            
+    if environ.get("SHARD") != "0":
+        remote_shard = [
+            f"{validatorToolbox.hmyAppPath}",
+            "blockchain",
+            "latest-headers",
+            f'--node=https://api.s{environ.get("SHARD")}.{environ.get("NETWORK_SWITCH")}.hmny.io',
+        ]
+        try:
+            result_remote_shard = run(remote_shard, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+            remote_data_shard = json.loads(result_remote_shard.stdout)
+            return remote_data_shard_0, local_data_shard, remote_data_shard
+        except (ValueError, KeyError, TypeError):
+            return
+        
+    return remote_data_shard_0, local_data_shard, None
+
+if __name__ == "__main__":
+    loadVarFile()
+    menuValidatorStats()
+    

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -63,23 +63,28 @@ def getFolders():
     if os.path.exists(f"{user_home}/harmony"):
         port = findPort(f'harmony')
         folders['harmony'] = port
-        print(f'Found ~/harmony folder, on port {port}')
+        print(f'* Found ~/harmony folder, on port {port}')
+        printStars()
     if os.path.exists(f"{user_home}/harmony0"):
         port = findPort(f'harmony0')
         folders['harmony1'] = port
-        print(f'Found ~/harmony1 folder, on port {port}')
+        print(f'* Found ~/harmony1 folder, on port {port}')
+        printStars()
     if os.path.exists(f"{user_home}/harmony1"):
         port = findPort(f'harmony1')
         folders['harmony2'] = port
-        print(f'Found ~/harmony1 folder, on port {port}')
+        print(f'* Found ~/harmony1 folder, on port {port}')
+        printStars()
     if os.path.exists(f"{user_home}/harmony2"):
         port = findPort(f'harmony2')
         folders['harmony3'] = port
-        print(f'Found ~/harmony2 folder, on port {port}')
+        print(f'* Found ~/harmony2 folder, on port {port}')
+        printStars()
     if os.path.exists(f"{user_home}/harmony3"):
         port = findPort(f'harmony3')
         folders['harmony4'] = port
-        print(f'Found ~/harmony3 folder, on port {port}')
+        print(f'* Found ~/harmony3 folder, on port {port}')
+        printStars()
     return folders
 
 
@@ -118,4 +123,3 @@ if __name__ == "__main__":
     refreshStats(1)
     folders = getFolders()
     statsOutputRegular(folders)
-    print('The end.')

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -82,7 +82,7 @@ def getFolders():
         print(f'Found ~/harmony3 folder, on port {port}')
     for folder in folders:
         #let's figure out what shards here.
-        local_server = [f"{}/{folder}/hmy blockchain latest-headers --node='https://localhost:{folders[folder]}'"]
+        local_server = [f"{user_home}/{folder}/hmy blockchain latest-headers --node='https://localhost:{folders[folder]}'"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         print(result_local_server)
     return folders

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -4,7 +4,7 @@ from os import environ
 from ast import literal_eval
 from utils.config import validatorToolbox
 from utils.library import loadVarFile, getSignPercent, getWalletBalance, printStars, setVar
-from utils.toolbox import freeSpaceCheck, harmonyServiceStatus
+from utils.toolbox import freeSpaceCheck, harmonyServiceStatus, getRewardsBalance
 from subprocess import PIPE, run
 from colorama import Fore, Back, Style
 

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -62,7 +62,7 @@ def statsOutputRegular() -> None:
     printStars()
     while count < 4:
         try:
-            remote_data, local_data = multiValidatorStats(count)
+            remote_data, local_data = multiValidatorStats(str(count))
             print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
             print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {count} Size: {getDBSize(str(count))}")
             printStars()

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -62,11 +62,11 @@ def statsOutputRegular() -> None:
     printStars()
     while count < 4:
         try:
-            count += 1
             remote_data, local_data = multiValidatorStats(count)
             print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
             print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {getDBSize(environ.get('SHARD'))}")
             printStars()
+            count += 1
         except (ValueError, KeyError, TypeError):
             print(f'Shard {count} not found.')
         

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -62,7 +62,7 @@ def statsOutputRegular() -> None:
     printStars()
     while count < 4:
         try:
-            count += count
+            count += 1
             remote_data, local_data = multiValidatorStats(count)
             print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
             print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {getDBSize(environ.get('SHARD'))}")

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -110,6 +110,7 @@ def statsOutputRegular(folders) -> None:
     remote_0_data = json.loads(result_shard_0.stdout)
     print(f"* Remote Shard 0 Epoch: {remote_0_data['result']['current-epoch']}, Current Block: {remote_0_data['result']['current-block-number']}")
     print(f"* Local Shard 0 Storage: {getDBSize('0')}")
+    printStars()
     for folder in folders:
         local_server = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=http://localhost:{folders[folder]}"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
@@ -119,7 +120,7 @@ def statsOutputRegular(folders) -> None:
         remote_data = json.loads(result_remote_server.stdout)
 
         print(f"* Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
-        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}, Local Shard {local_data['result']['shard-id']} Size: {getDBSize(local_data['result']['shard-id'])}")
+        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}\nLocal Shard {local_data['result']['shard-id']} Size: {getDBSize(local_data['result']['shard-id'])}")
         printStars()
 
 if __name__ == "__main__":

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -47,7 +47,7 @@ if not environ.get("NETWORK_SWITCH"):
 
 # Search harmony.conf for the proper port to hit
 def findPort(folder):
-    with open(f'{validatorToolbox.harmonyDirPath}/{folder}/harmony.conf') as f:
+    with open(f'{user_home}/{folder}/harmony.conf') as f:
         datafile = f.readlines()
     count = 0
     for line in datafile:

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -42,7 +42,6 @@ if not environ.get("NETWORK_SWITCH"):
         setVar(validatorToolbox.dotenv_file, "NETWORK_SWITCH", "b")
         setVar(validatorToolbox.dotenv_file, "RPC_NET", "https://rpc.s0.b.hmny.io")
     os.system("clear")
-    return
 
 def statsOutputRegular() -> None:
     # Get server stats & wallet balances

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -105,7 +105,11 @@ def statsOutputRegular(folders) -> None:
     print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}\n* Current disk space free: {Fore.CYAN}{freeSpaceCheck(): >6}{Style.RESET_ALL}\n* Current harmony version: {Fore.YELLOW}{environ.get("HARMONY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HARMONY_UPGRADE_AVAILABLE")}\n* Current hmy version: {Fore.YELLOW}{environ.get("HMY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HMY_UPGRADE_AVAILABLE")}')
     print(f"* CPU Load Averages: {round(Load1, 2)} over 1 min, {round(Load5, 2)} over 5 min, {round(Load15, 2)} over 15 min")
     printStars()
-    count = 0
+    remote_shard_0 = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=https://api.s0.t.hmny.io"]
+    result_shard_0 = run(remote_shard_0, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    remote_0_data = json.loads(result_shard_0.stdout)
+    print(f"* Remote Shard 0 Epoch: {remote_0_data['result']['current-epoch']}, Current Block: {remote_0_data['result']['current-block-number']}")
+    print(f"* Local Shard 0 Storage: {getDBSize("0")}")
     for folder in folders:
         local_server = [f"{user_home}/{folder}/hmy", "utility", "metadata", f"--node=http://localhost:{folders[folder]}"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
@@ -115,7 +119,7 @@ def statsOutputRegular(folders) -> None:
         remote_data = json.loads(result_remote_server.stdout)
 
         print(f"* Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
-        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}, Local Shard {local_data['result']['shard-id']} Size: {getDBSize(str(count))}")
+        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}, Local Shard {local_data['result']['shard-id']} Size: {getDBSize(local_data['result']['shard-id'])}")
         printStars()
 
 if __name__ == "__main__":

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -13,8 +13,6 @@ loadVarFile()
 
 user_home = f'{os.path.expanduser("~")}'
 
-validatorToolbox.harmonyDirPath
-
 if not environ.get("VALIDATOR_WALLET"):
     # ask for wallet, save to env.
     address = input(f'No Harmony $ONE address found, please input a one1 or 0x address: ')
@@ -60,34 +58,35 @@ def findPort(folder):
             count += 1
 
 # build list of installs
-if not os.path.exists(f"{}"):
-    print(f'* Checking for custom folders.')
+def getFolders():
     folders = {}
-    if os.path.exists(f"{validatorToolbox.harmonyDirPath}"):
+    if os.path.exists(f"{user_home}/harmony"):
         port = findPort(f'harmony')
         folders['harmony'] = port
         print(f'Found ~/harmony folder, on port {port}')
-    if os.path.exists(f"{validatorToolbox.harmonyDirPath}0"):
+    if os.path.exists(f"{user_home}/harmony0"):
         port = findPort(f'harmony0')
         folders['harmony1'] = port
         print(f'Found ~/harmony1 folder, on port {port}')
-    if os.path.exists(f"{validatorToolbox.harmonyDirPath}1"):
+    if os.path.exists(f"{user_home}/harmony1"):
         port = findPort(f'harmony1')
         folders['harmony2'] = port
         print(f'Found ~/harmony1 folder, on port {port}')
-    if os.path.exists(f"{validatorToolbox.harmonyDirPath}2"):
+    if os.path.exists(f"{user_home}/harmony2"):
         port = findPort(f'harmony2')
         folders['harmony3'] = port
         print(f'Found ~/harmony2 folder, on port {port}')
-    if os.path.exists(f"{validatorToolbox.harmonyDirPath}3"):
+    if os.path.exists(f"{user_home}/harmony3"):
         port = findPort(f'harmony3')
         folders['harmony4'] = port
         print(f'Found ~/harmony3 folder, on port {port}')
     for folder in folders:
         #let's figure out what shards here.
-        local_server = [f"{validatorToolbox.userHomeDir}/{folder}/hmy blockchain latest-headers --node='https://localhost:{folders[folder]}'"]
+        local_server = [f"{}/{folder}/hmy blockchain latest-headers --node='https://localhost:{folders[folder]}'"]
         result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         print(result_local_server)
+    return folders
+
 
 def statsOutputRegular() -> None:
     # Get server stats & wallet balances
@@ -141,4 +140,5 @@ if __name__ == "__main__":
     # loaderIntro()
     # refreshStats(1)
     # statsOutputRegular()
+    folders = getFolders()
     print('The end.')

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -63,8 +63,8 @@ def statsOutputRegular() -> None:
     while count < 4:
         try:
             remote_data, local_data = multiValidatorStats()
-            print(f"* Remote Shard {environ.get('SHARD')} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
-            print(f"*  Local Shard {environ.get('SHARD')} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {getDBSize(environ.get('SHARD'))}")
+            print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
+            print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {environ.get('SHARD')} Size: {getDBSize(environ.get('SHARD'))}")
             printStars()
         except (ValueError, KeyError, TypeError):
             return

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -80,12 +80,6 @@ def getFolders():
         port = findPort(f'harmony3')
         folders['harmony4'] = port
         print(f'Found ~/harmony3 folder, on port {port}')
-    for folder in folders:
-        #let's figure out what shards here.
-        local_server = [f"{user_home}/{folder}/hmy", "blockchain", "latest-headers", f"--node=http://localhost:{folders[folder]}"]
-        result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-        local_data = json.loads(result_local_server.stdout)
-        print(result_local_server)
     return folders
 
 
@@ -106,14 +100,15 @@ def statsOutputRegular() -> None:
     print(f'* Epoch Signing Percentage:         {Style.BRIGHT}{Fore.GREEN}{Back.BLUE}{sign_percentage} %{Style.RESET_ALL}\n* Current disk space free: {Fore.CYAN}{freeSpaceCheck(): >6}{Style.RESET_ALL}\n* Current harmony version: {Fore.YELLOW}{environ.get("HARMONY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HARMONY_UPGRADE_AVAILABLE")}\n* Current hmy version: {Fore.YELLOW}{environ.get("HMY_VERSION")}{Style.RESET_ALL}, has upgrade available: {environ.get("HMY_UPGRADE_AVAILABLE")}')
     print(f"* CPU Load Averages: {round(Load1, 2)} over 1 min, {round(Load5, 2)} over 5 min, {round(Load15, 2)} over 15 min")
     printStars()
+
     for folder in folders:
-        try:
-            remote_data, local_data = multiValidatorStats(folder)
-            print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
-            print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {count} Size: {getDBSize(str(count))}")
-            printStars()
-        except (ValueError, KeyError, TypeError):
-            print(f'Shard {count} not found.')
+        #let's figure out what shards here.
+        local_server = [f"{user_home}/{folder}/hmy", "blockchain", "latest-headers", f"--node=http://localhost:{folders[folder]}"]
+        result_local_server = run(local_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        local_data = json.loads(result_local_server.stdout)
+        print(f"* Remote Shard {count} Epoch: {remote_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(remote_data['result']['shard-chain-header']['number'])}")
+        print(f"*  Local Shard {count} Epoch: {local_data['result']['shard-chain-header']['epoch']}, Current Block: {literal_eval(local_data['result']['shard-chain-header']['number'])}, Local Shard {count} Size: {getDBSize(str(count))}")
+        printStars()
         
 
 def multiValidatorStats(folder):
@@ -138,8 +133,8 @@ def multiValidatorStats(folder):
     return remote_data, local_data
 
 if __name__ == "__main__":
-    # loaderIntro()
-    # refreshStats(1)
-    # statsOutputRegular()
+    loaderIntro()
+    refreshStats(1)
     folders = getFolders()
+    statsOutputRegular(folders)
     print('The end.')

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -83,7 +83,7 @@ def multiValidatorStats(shard):
     remote_data = json.loads(result_remote_shard.stdout)
 
     # local stuff
-    local_shard = [f"{validatorToolbox.hmyAppPath}", "blockchain", "latest-headers", f'--node=https://localhost:950{shard}']
+    local_shard = [f"{validatorToolbox.hmyAppPath}", "blockchain", "latest-headers", f'--node=http://localhost:950{shard}']
     result_local_shard = run(local_shard, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     local_data = json.loads(result_local_shard.stdout)
         

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -113,28 +113,6 @@ def statsOutputRegular(folders) -> None:
         print(f"* Remote Shard {count} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
         print(f"*  Local Shard {count} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}, Local Shard {local_data['result']['shard-id']} Size: {getDBSize(str(count))}")
         printStars()
-        
-
-def multiValidatorStats(folder):
-    loadVarFile()
-    remote_shard = [
-        f"{validatorToolbox.userHomeDir}/{folders[folder]}/hmy",
-        "blockchain",
-        "latest-headers",
-        f'--node=https://api.s{shard}.{environ.get("NETWORK_SWITCH")}.hmny.io',
-    ]
-    result_remote_shard = run(remote_shard, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    remote_data = json.loads(result_remote_shard.stdout)
-
-    # local stuff
-    if folder == "harmony":
-        local_shard = [f"{validatorToolbox.harmonyDirPath}/hmy", "blockchain", "latest-headers"]
-        result_local_shard = run(local_shard, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-        local_data = json.loads(result_local_shard.stdout)
-    else:
-        local_shard = [f"{validatorToolbox.userHomeDir}/{folder}/hmy", "blockchain", "latest-headers", f"--node=http://localhost:{folder[1]}"]
-        
-    return remote_data, local_data
 
 if __name__ == "__main__":
     loaderIntro()

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -4,7 +4,7 @@ from os import environ
 from ast import literal_eval
 from utils.config import validatorToolbox
 from utils.library import loadVarFile, getSignPercent, getWalletBalance, printStars, setVar
-from utils.toolbox import menuTopperRegular, freeSpaceCheck, harmonyServiceStatus
+from utils.toolbox import freeSpaceCheck, harmonyServiceStatus
 from subprocess import PIPE, run
 from colorama import Fore, Back, Style
 
@@ -17,7 +17,7 @@ if not environ.get("VALIDATOR_WALLET"):
     if address == address2:
         setVar(validatorToolbox.dot_env, "VALIDATOR_WALLET", address2)
 
-def menuTopperRegular() -> None:
+def statsOutputRegular() -> None:
     # Get stats & balances
     Load1, Load5, Load15 = os.getloadavg()
     sign_percentage = getSignPercent()
@@ -73,5 +73,5 @@ def menuValidatorStats():
     return remote_data_shard_0, local_data_shard, None
 
 if __name__ == "__main__":
-    menuValidatorStats()
+    statsOutputRegular()
     

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -119,8 +119,8 @@ def statsOutputRegular(folders) -> None:
         result_remote_server = run(remote_server, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         remote_data = json.loads(result_remote_server.stdout)
 
-        print(f"*  Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
-        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}\n*  Local Shard {local_data['result']['shard-id']} Size: {getDBSize(local_data['result']['shard-id'])}")
+        print(f"* Remote Shard {local_data['result']['shard-id']} Epoch: {remote_data['result']['current-epoch']}, Current Block: {remote_data['result']['current-block-number']}")
+        print(f"*  Local Shard {local_data['result']['shard-id']} Epoch: {local_data['result']['current-epoch']}, Current Block: {(local_data['result']['current-block-number'])}\n*   Local Shard {local_data['result']['shard-id']} Size: {getDBSize(local_data['result']['shard-id'])}")
         printStars()
 
 if __name__ == "__main__":

--- a/toolbox/multi_stats.py
+++ b/toolbox/multi_stats.py
@@ -133,4 +133,4 @@ if __name__ == "__main__":
     # loaderIntro()
     # refreshStats(1)
     # statsOutputRegular()
-    
+    print('The end.')

--- a/toolbox/utils/library.py
+++ b/toolbox/utils/library.py
@@ -59,6 +59,7 @@ def setVar(fileName, keyName, updateName):
 
 # loader intro splash screen
 def loaderIntro():
+    os.system("clear")
     p = f"""
                     ____ ____ ____ ____ _________ ____ ____ ____ ____           
                     ||E |||a |||s |||y |||       |||N |||o |||d |||e ||          

--- a/toolbox/utils/toolbox.py
+++ b/toolbox/utils/toolbox.py
@@ -1,9 +1,6 @@
 import os
-import shutil
-from wsgiref.validate import validator
 import requests
 import time
-import dotenv
 import json
 import subprocess
 from subprocess import Popen, PIPE, run
@@ -11,7 +8,6 @@ from ast import literal_eval
 from utils.config import validatorToolbox
 from os import environ
 from datetime import datetime
-from collections import namedtuple
 from colorama import Fore, Back, Style
 from pyhmy import blockchain, transaction
 from requests.exceptions import HTTPError
@@ -30,6 +26,7 @@ from utils.library import (
     getRewardsBalance,
     stringStars,
     setVar,
+    freeSpaceCheck
 )
 from utils.allsysinfo import allSysInfo
 
@@ -371,91 +368,6 @@ def harmonyServiceStatus() -> None:
         print("* Harmony Service is:               " + Fore.BLACK + Back.GREEN + "   Online  " + Style.RESET_ALL)
     else:
         print("* Harmony Service is:               " + Fore.WHITE + Back.RED + "  *** Offline *** " + Style.RESET_ALL)
-
-
-def diskFreeSpace(mountPoint: str) -> str:
-    _, _, free = shutil.disk_usage(mountPoint)
-    free = str(convertedUnit(free))
-    return free
-
-
-def freeSpaceCheck() -> str:
-    ourDiskMount = get_mount_point(validatorToolbox.harmonyDirPath)
-    _, _, free = shutil.disk_usage(ourDiskMount)
-    free = diskFreeSpace(ourDiskMount)
-    return free
-
-
-def serverDriveCheck() -> None:
-    if environ.get("MOUNT_POINT") is not None:
-        ourDiskMount = environ.get("MOUNT_POINT")
-    else:
-        dotenv.set_key(validatorToolbox.dotenv_file, "MOUNT_POINT", validatorToolbox.harmonyDirPath)
-        loadVarFile()
-        ourDiskMount = environ.get("MOUNT_POINT")
-    printStarsReset()
-    print("Here are all of your mount points: ")
-    for part in disk_partitions():
-        print(part)
-    printStars()
-    total, used, free = shutil.disk_usage(ourDiskMount)
-    total = str(convertedUnit(total))
-    used = str(convertedUnit(used))
-    print("Disk: " + str(ourDiskMount) + "\n" + freeSpaceCheck() + " Free\n" + used + " Used\n" + total + " Total")
-    printStars()
-    input("Disk check complete, press ENTER to return to the main menu. ")
-
-
-def disk_partitions(all=False):
-    disk_ntuple = namedtuple("partition", "device mountpoint fstype")
-    # Return all mounted partitions as a nameduple.
-    # If all == False return physical partitions only.
-    phydevs = []
-    with open("/proc/filesystems", "r") as f:
-        for line in f:
-            if not line.startswith("nodev"):
-                phydevs.append(line.strip())
-
-    retlist = []
-    with open("/etc/mtab", "r") as f:
-        for line in f:
-            if not all and line.startswith("none"):
-                continue
-            fields = line.split()
-            device = fields[0]
-            mountpoint = fields[1]
-            fstype = fields[2]
-            if not all and fstype not in phydevs:
-                continue
-            if device == "none":
-                device = ""
-            ntuple = disk_ntuple(device, mountpoint, fstype)
-            retlist.append(ntuple)
-    return retlist
-
-
-def get_mount_point(pathname):
-    pathname = os.path.normcase(os.path.realpath(pathname))
-    parent_device = path_device = os.stat(pathname).st_dev
-    while parent_device == path_device:
-        mount_point = pathname
-        pathname = os.path.dirname(pathname)
-        if pathname == mount_point:
-            break
-        parent_device = os.stat(pathname).st_dev
-    return mount_point
-
-
-def convertedUnit(n):
-    symbols = ("K", "M", "G", "T", "P", "E", "Z", "Y")
-    prefix = {}
-    for i, s in enumerate(symbols):
-        prefix[s] = 1 << (i + 1) * 10
-    for s in reversed(symbols):
-        if n >= prefix[s]:
-            value = float(n) / prefix[s]
-            return "%.1f%s" % (value, s)
-    return "%sB" % n
 
 
 def serviceMenuOption() -> None:

--- a/toolbox/utils/toolbox.py
+++ b/toolbox/utils/toolbox.py
@@ -26,7 +26,8 @@ from utils.library import (
     getRewardsBalance,
     stringStars,
     setVar,
-    freeSpaceCheck
+    freeSpaceCheck,
+    serverDriveCheck
 )
 from utils.allsysinfo import allSysInfo
 


### PR DESCRIPTION
Moved some stuff to the library that's shared, added multi_stats.py.

**multi_stats.py**

Run anywhere with
`python3 ~/validatortoolbox/toolbox/multi_stats.py`

This script checks for folders named ~/harmony, ~/harmony0, ~/harmony1, ~/harmony2, & ~/harmony3 for people with multi-shard installs. Works with just 1 or multiple.